### PR TITLE
Fix link issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: keycloak_flutter
 description: Keycloak client adapter for flutter based on the keycloak-js implementation.
 version: 0.0.2-pre
-homepage: https://github.com/gibahjoe/keycloak-dart
+homepage: https://github.com/gibahjoe/keycloak_flutter
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Hey,
thanks a lot for this awesome plugin. I found it via https://pub.dev/packages/keycloak_flutter. After i tried to click on the links on that webpage to head over to github, i thought this repo does not exist anymore, as the link points to a none existing github repo. See the fix in the PR.

Keep on the good work :)