### PR TITLE
Do not implement Future on KeycloakPromise

### DIFF
--- a/lib/src/keycloak.dart
+++ b/lib/src/keycloak.dart
@@ -330,7 +330,7 @@ typedef void KeycloakPromiseCallback<T>(T result);
 
 @anonymous
 @JS()
-abstract class KeycloakPromise<TSuccess, TError> implements Future<TSuccess> {
+abstract class KeycloakPromise<TSuccess, TError> {
   /// Function to call if the promised action succeeds.
   /// Use `.then()` instead.
   external KeycloakPromise<TSuccess, TError> success(

--- a/lib/src/keycloak_service.dart
+++ b/lib/src/keycloak_service.dart
@@ -82,7 +82,7 @@ class KeycloakService {
     this._userProfile = null;
   }
 
-  FutureOr<KeycloakProfile?> loadUserProfile([bool forceReload = false]) async {
+  Future<KeycloakProfile?> loadUserProfile([bool forceReload = false]) async {
     if (this._userProfile != null && !forceReload) {
       return this._userProfile!;
     }

--- a/lib/src/keycloak_service.dart
+++ b/lib/src/keycloak_service.dart
@@ -82,7 +82,7 @@ class KeycloakService {
     this._userProfile = null;
   }
 
-  Future<KeycloakProfile?> loadUserProfile([bool forceReload = false]) async {
+  FutureOr<KeycloakProfile?> loadUserProfile([bool forceReload = false]) async {
     if (this._userProfile != null && !forceReload) {
       return this._userProfile!;
     }


### PR DESCRIPTION
Implementing future on KeycloakPromise causes an exception in release mode during future chaining.  This is seen in issue #17.  This pull request should resolve the issue.